### PR TITLE
Remove sponsor links from bottom of every page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,13 +37,13 @@
       <div id="center_column">
         <%= yield :layout %>
 
-        <div id="footer">
+        <!-- <div id="footer">
           <br />
           <br />
           <p style="text-align: center">
             <%= link_to t(:sponsors), content_path("sponsors") %>
           </p>
-        </div>
+        </div> -->
       </div>
       <div id="right_column">
         <%= tags %>


### PR DESCRIPTION
I suggest moving the sponsor links to the imprint, so that they are not displayed on every single page and press release.
• remove sponsors inks from application.html.erb
• remove div #footer from application.html.erb

