### PR TITLE
template that shows an SVG map stored as asset 327

### DIFF
--- a/app/views/custom/page_templates/public/no_date_and_author_with_map.html.erb
+++ b/app/views/custom/page_templates/public/no_date_and_author_with_map.html.erb
@@ -1,7 +1,7 @@
 <div class="article">
   <h2 class="headline"><%= @page.title %></h2>
   <p><%= sanitize( @page.abstract ) %></p>
-  <object data="/system/uploads/328/original/regional.svg" type="image/svg+xml"/>
+  <object data="/system/uploads/327/original/map.svg" type="image/svg+xml"/>
   <%= aggregate?(@page.body) %>
 </div>
 

--- a/app/views/custom/page_templates/public/no_date_and_author_with_map.html.erb
+++ b/app/views/custom/page_templates/public/no_date_and_author_with_map.html.erb
@@ -1,0 +1,8 @@
+<div class="article">
+  <h2 class="headline"><%= @page.title %></h2>
+  <p><%= sanitize( @page.abstract ) %></p>
+  <object data="/system/uploads/328/original/regional.svg" type="image/svg+xml"/>
+  <%= aggregate?(@page.body) %>
+</div>
+
+<%= will_paginate(@content_collection) if @content_collection %>


### PR DESCRIPTION
The goal is to replace the regional map at https://www.ccc.de/regional with an SVG. An SVG map has two improvements over the current PNG map:

1. It has clickable links pointing to the Erfas and Chaostreffs on https://www.ccc.de/de/club/chaostreffs or https://www.ccc.de/de/club/erfas
2. It's quite easy to auto generate from the data at the doku wiki with some Python

A sample SVG map can be seen at https://www.ccc.de/system/uploads/327/original/map.svg

This PR is the minimal viable way to place the SVG by simply replacing the header image with a static link to the above asset URL. Suggestions for how to better implement this are welcome.